### PR TITLE
Optional:  Evidence connThreshold arbitrary restarts cause 502's

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -166,7 +166,7 @@ var Process = module.exports = function Process(options) {
                         aggr = {};
 
                     _.each(_.range(0, count), function(aggregated){
-                        
+
                         var heartbeat = self._heartbeats.shift();
 
                         _.each(heartbeat, function(val, key){
@@ -203,7 +203,7 @@ var Process = module.exports = function Process(options) {
                     _.each(self.stats.workers, function (workerStats, pid) {
                         var now = Date.now();
                         if (now - workerStats.lastHeartbeatAt> self.options.maxHeartbeatDelay) {
-                            // this worker hasn't been sending heartbeat for maxHeartbeatDelay 
+                            // this worker hasn't been sending heartbeat for maxHeartbeatDelay
                             log(util.format('[Cluster2] Detected worker%d is not responsive for %d', pid, now - workerStats.lastHeartbeatAt));
                             var deathQueue = require('./misc').deathQueue;
                             deathQueue(self.workers[pid], self.emitter, function () {
@@ -215,7 +215,7 @@ var Process = module.exports = function Process(options) {
                             });
                         }
                     });
-                    
+
                 }, self.options.heartbeatInterval || 60000);
             }
             else if(message.type === 'suicide'){ //TODO, deathQueue
@@ -324,7 +324,7 @@ var Process = module.exports = function Process(options) {
             }
             catch(error){
                 log('[cluster2] cannot send message to worker:' + pid);
-            } 
+            }
         });
     }
 }
@@ -354,7 +354,7 @@ Process.prototype.listen = function() {
         cb = arguments[1];
     }
     if(cluster.isMaster) {
-        
+
         this.stats.pid = process.pid;
         this.stats.start = new Date();
         this.stats.totalmem = os.totalmem();
@@ -398,9 +398,9 @@ Process.prototype.listen = function() {
             }
 
             var deathWatcher = function (worker, code, signal) {
-                
+
                 worker = worker.process;
-                
+
                 log('[cluster2] death watch activated, worker:' + worker.pid + '\tcode:' + code + '\tsignal:' + signal + '\texit:' + worker.exitCode);
                 if(code === 0) {
                     self.emitter.emit('died', worker.pid);
@@ -465,7 +465,7 @@ Process.prototype.listen = function() {
         });
     }
     else {
-        
+
         var listening = false, conns = 0, totalConns = 0, timedoutConns = 0, noAppClosed = 0, graceful = _.once(function graceful(signal, code){
 
             _.each(apps, function(app){
@@ -504,10 +504,10 @@ Process.prototype.listen = function() {
         });
 
         process.on('SIGINT', function() {
-            
+
             graceful('SIGINT', 0);
         });
-        
+
         process.on('SIGTERM', function() {
 
             log(process.pid, 'got SIGTERM');
@@ -522,7 +522,7 @@ Process.prototype.listen = function() {
             totalConns++;
             //idle timeout
             conn.setTimeout(self.options.timeout, function () {
-                    
+
                     timedoutConns++;
                     self.emitter.emit('warning', {
                         message: 'Client socket timed out'
@@ -574,7 +574,7 @@ Process.prototype.listen = function() {
                     }
                     cb();
                     //redundant for express2, absolutely needed for express3 and above
-                    app.app.emit('listening');    
+                    app.app.emit('listening');
                 });
                 server.on('connection', monitorConnection);
                 app.server = server;
@@ -589,19 +589,20 @@ Process.prototype.listen = function() {
 
         var recycle = setInterval(function() {
 
-                var uptime = process.uptime();
-                if(totalConns > connThreshold || uptime >= uptimeThreshold) {
-                    
-                    log('[cluster2] exit because of connThreshold:' + connThreshold + ':' + totalConns + '; or uptime:' + uptime + ' has exceeded:' + uptimeThreshold);
-                    clearInterval(recycle);
-
-                    //wait for master's order
-                    process.send({
-                        'type': 'suicide'
-                    });
-                }
-            },  
-            1000);
+                /** XXX: I don't want this behavior at all */
+                // var uptime = process.uptime();
+                // if(totalConns > connThreshold || uptime >= uptimeThreshold) {
+                //
+                //     log('[cluster2] exit because of connThreshold:' + connThreshold + ':' + totalConns + '; or uptime:' + uptime + ' has exceeded:' + uptimeThreshold);
+                //     clearInterval(recycle);
+                //
+                //     //wait for master's order
+                //     process.send({
+                //         'type': 'suicide'
+                //     });
+                // }
+            },
+            100000);
 
         var memStats = {
             'num_full_gc': 0,
@@ -626,7 +627,7 @@ Process.prototype.listen = function() {
 
         // Heartbeat - make sure to clear this on 'close'
         var heartbeat = setInterval(function () {
-            
+
             usage.lookup(process.pid, function(err, result) {
 
                 if(!err){
@@ -668,15 +669,15 @@ Process.prototype.listen = function() {
             });
 
         }, self.options.heartbeatInterval || 60000);
-        // put the heartbeat interval id in the process context 
+        // put the heartbeat interval id in the process context
         process.heartbeat = heartbeat;
 
         _.each(apps, function(app){
 
             app.app.once('close', function() {
-                
+
                 noAppClosed++;
-                
+
                 if(noAppClosed >= noAppClosed.length){
                     clearInterval(heartbeat);
                     clearInterval(recycle);
@@ -699,4 +700,3 @@ Process.prototype.shutdown = function() {
     log('Shutdown request received - emitting SIGTERM');
     this.emitter.emit('SIGTERM');
 };
-


### PR DESCRIPTION
- Tested epistream after removing these unnecessary restarts and do  not see evidence of memory leaks
- There is no reason to have the workers die randomly for no reason
- Cluster 2 doesn't provide an option to disable this behavior - only settings to adjust it
- Deleting behavior for Marklar